### PR TITLE
CreeperML | ASM

### DIFF
--- a/CreeperML/build.sh
+++ b/CreeperML/build.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+LOGO=1
+DIR=1
+BINDINGS="../lib/bindings.o"
+
+while getopts "ldb:" flag; do
+  case "${flag}" in
+    "l") LOGO=0 ;;
+    "d") DIR=0 ;;
+    "b") BINDINGS=$OPTARG ;;
+  esac
+done
+
+cd "./cm_build"
+
+if [[ $DIR -eq 1 ]]
+then
+  echo "Executing build in $PWD..."
+  echo "Compiling program..."
+fi
+
+nasm -f elf64 program.asm -o program.o 1> /dev/null 2> /dev/null
+if [[ $? -ne 0 ]]
+then
+  echo -e "${RED}Error compiling program"
+  echo -e "${RED}Failure"
+  exit $?
+fi
+
+if [[ $DIR -eq 1 ]]
+then
+  echo "Linking program..."
+fi
+
+gcc $BINDINGS program.o -o program 1> /dev/null 2> /dev/null
+if [[ $? -ne 0 ]]
+then
+  echo -e "${RED}Error linking stuff"
+  echo -e "${RED}Failure"
+  exit $?
+fi
+
+# print successful run
+if [[ $LOGO -eq 1 ]]
+then
+  echo
+  echo -e "${GREEN}   ___     ___        _____                               __  __ _"
+  echo -e "${GREEN}  |   |   |   |      / ____|                             |  \/  | |"
+  echo -e "${GREEN}  |___|___|___|     | |     _ __ ___  ___ _ __   ___ _ __| \  / | |"
+  echo -e "${GREEN}     _|   |_        | |    | '__/ _ \/ _ \ '_ \ / _ \ '__| |\/| | |"
+  echo -e "${GREEN}    |  ___  |       | |____| | |  __/  __/ |_) |  __/ |  | |  | | |____"
+  echo -e "${GREEN}    |_|   |_|        \_____|_|  \___|\___| .__/ \___|_|  |_|  |_|______|"
+  echo -e "${GREEN}                                         |_|"
+  echo -e "👌 ${NC}Successful run"
+fi

--- a/CreeperML/lib/asm.ml
+++ b/CreeperML/lib/asm.ml
@@ -162,7 +162,7 @@ module Asm = struct
     | "/" -> return [ mov rax rdi; cqo; idiv rsi ] (* / *)
     | "<=" -> return [ cmp rdi rsi; setle al; movzx eax al ] (* <= *)
     | "<" -> return [ cmp rdi rsi; setl al; movzx eax al ] (* < *)
-    | "=" -> return [ cmp rdi rsi; sete al; movzx eax al ] (* == *)
+    | "==" -> return [ cmp rdi rsi; sete al; movzx eax al ] (* == *)
     | ">" -> return [ cmp rdi rsi; setg al; movzx eax al ] (* > *)
     | ">=" -> return [ cmp rdi rsi; setge al; movzx eax al ] (* >= *)
     | "print_int" -> [ call "bin_print_int" ] >>> stack_fix |> return

--- a/CreeperML/lib/asm.ml
+++ b/CreeperML/lib/asm.ml
@@ -1,0 +1,477 @@
+module Asm = struct
+  open Anf.AnfTypeAst
+  open Type_ast.TypeAst
+  open Parser_ast.ParserAst
+  open Std
+  open Monad.Result
+
+  let reg_size = 16
+  let ptr_size = 8
+
+  type reg = string
+
+  type storage =
+    | Stack of int
+    | Reg of reg
+    | IntConst of int
+    | Displacement of string * int
+    | Fndef of string
+
+  type instruction =
+    | Mov of storage * storage
+    | Movzx of storage * storage
+    | Add of storage * storage
+    | Sub of storage * storage
+    | Imul of storage * storage
+    | Idiv of storage
+    | Call of string
+    | Push of storage
+    | Pop of storage
+    | Int of int
+    | Ret
+    | Jmp of string
+    | Je of string
+    | Jne of string
+    | Cmp of storage * storage
+    | Setge of storage
+    | Setg of storage
+    | Setle of storage
+    | Setl of storage
+    | Sete of storage
+    | Label of string (* bad *)
+    | Cqo
+
+  type fn = { name : string; body : instruction list }
+
+  let rax = Reg "rax"
+  let rdi = Reg "rdi"
+  let rsi = Reg "rsi"
+  let al = Reg "al"
+  let eax = Reg "eax"
+  let rsp = Reg "rsp"
+  let rbp = Reg "rbp"
+  let rdx = Reg "rdx"
+  let rcx = Reg "rcx"
+  let r8 = Reg "r8"
+  let r9 = Reg "r9"
+  let r12 = Reg "r12"
+  let pop l = Pop l
+  let add r1 r2 = Add (r1, r2)
+  let imul r1 r2 = Imul (r1, r2)
+  let sub r1 r2 = Sub (r1, r2)
+  let idiv r = Idiv r
+  let push l = Push l
+  let ic i = IntConst i
+  let mov r1 r2 = Mov (r1, r2)
+  let setle r = Setle r
+  let setl r = Setl r
+  let setge r = Setge r
+  let setg r = Setg r
+  let sete r = Sete r
+  let movzx r1 r2 = Movzx (r1, r2)
+  let cmp r1 r2 = Cmp (r1, r2)
+  let call r = Call r
+  let je x = Je x
+  let cqo = Cqo
+  let dp reg d = Displacement (reg, d)
+
+  module SMap = Map.Make (String)
+
+  type compiler_info = {
+    memory : storage SMap.t;
+    functions : string list;
+    arities : int SMap.t;
+  }
+
+  let latest_if_id = ref 0
+
+  let gen_next_if_id () =
+    latest_if_id := !latest_if_id + 1;
+    !latest_if_id
+
+  let ( >> ) x y = x @ [ y ]
+  let ( >>> ) = ( @ )
+  let ( =>> ) x y = x >>| fun x -> x @ [ y ]
+  let ( =>>> ) x y = x >>| fun x -> x @ y
+  let ( ->>> ) x y = y >>| fun y -> x @ y
+
+  let ( |>>> ) x y =
+    x >>= fun x ->
+    y >>| fun y -> x @ y
+
+  let lst x = [ x ]
+  let concat = List.concat
+
+  let rec arity_of t =
+    match t with TyArrow (_, t2) -> 1 + arity_of t2 | _ -> 0
+
+  let std_functions = Std.operators |> List.map (fun x -> x.value)
+  let sizeof _ = 8
+  let align16 x = if Int.rem x 16 <> 0 then x - Int.rem x 16 + 16 else x
+  let sum_by f = List.fold_left (fun xs x -> xs + f x) 0
+
+  (*  %rdi, %rsi, %rdx, %rcx, %r8, and %r9 then stack *)
+  let get_arg_loc = function
+    | 0 -> Some rdi
+    | 1 -> Some rsi
+    | 2 -> Some rdx
+    | 3 -> Some rcx
+    | 4 -> Some r8
+    | 5 -> Some r9
+    | _ -> None
+
+  let split_args lst =
+    let rec helper lst i (acc1, acc2) =
+      match (lst, get_arg_loc i) with
+      | [], _ -> (acc1, acc2)
+      | hd :: tl, Some _ -> helper tl (i + 1) (hd :: acc1, acc2)
+      | hd :: tl, None -> helper tl (i + 1) (acc1, hd :: acc2)
+    in
+    helper lst 0 ([], [])
+
+  let rec collect_locals l =
+    match l.e with
+    | Aite (_, t, e) ->
+        List.concat_map collect_locals t.lets
+        @ List.concat_map collect_locals e.lets
+        @ [ l.name ]
+    | _ -> [ l.name ]
+
+  let map_fn_stack (fn : anf_fun_binding) =
+    let empty = SMap.empty in
+    let inner sign (mm, li) x =
+      (SMap.add x.value (Stack li) mm, sign li (sizeof x.typ))
+    in
+    let reg_args, stack_args = split_args (fn.env @ fn.args) in
+    let all_local_vars = List.concat_map collect_locals fn.body.lets in
+    let args, last = List.fold_left (inner ( - )) (empty, -reg_size) reg_args in
+    let args, _ = List.fold_left (inner ( + )) (args, reg_size) stack_args in
+    List.fold_left (inner ( - )) (args, last) all_local_vars |> fst
+
+  let compile_fn_call fn args =
+    let stack_len =
+      List.filteri (fun i _ -> Option.is_none (get_arg_loc i)) args
+      |> List.fold_left (fun xs x -> xs + sizeof x) 0
+    in
+    let stack_fix = [ add rsp (stack_len |> align16 |> ic) ] in
+    match fn with
+    (* Inline function call here *)
+    | "-" -> return [ sub rdi rsi; mov rax rdi ] (* - *)
+    | "+" -> return [ add rdi rsi; mov rax rdi ] (* + *)
+    | "*" -> return [ imul rdi rsi; mov rax rdi ] (* * *)
+    | "/" -> return [ mov rax rdi; cqo; idiv rsi ] (* / *)
+    | "<=" -> return [ cmp rdi rsi; setle al; movzx eax al ] (* <= *)
+    | "<" -> return [ cmp rdi rsi; setl al; movzx eax al ] (* < *)
+    | "==" -> return [ cmp rdi rsi; sete al; movzx eax al ] (* == *)
+    | ">" -> return [ cmp rdi rsi; setg al; movzx eax al ] (* > *)
+    | ">=" -> return [ cmp rdi rsi; setge al; movzx eax al ] (* >= *)
+    | x when String.ends_with ~suffix:"." x ->
+        error "Compiler error: Float point functions not done"
+    | other -> [ call other ] >>> stack_fix |> return
+
+  let int_of_literal x =
+    match x.value with
+    | LInt x -> return x
+    | LBool true -> return 1
+    | LBool false -> return 0
+    | LUnit -> return 0
+    | LString _ -> error "Compiler error: Strings are not supported yet"
+    | LFloat _ -> error "Compiler error: Floats are not supported yet"
+
+  let preserve_reg reg prog =
+    [ push reg; sub rsp (ic 8) ] >>> prog >>> [ add rsp (ic 8); pop reg ]
+
+  let mem_imm cinfo imm =
+    match imm with
+    | ImmVal v when List.mem v.value cinfo.functions -> Fndef v.value |> return
+    | ImmVal x -> (
+        match SMap.find_opt x.value cinfo.memory with
+        | Some x -> return x
+        | None -> error "Compiler error: Could not find variable in memory")
+    | ImmLit l -> int_of_literal l >>| ic
+
+  let alloc_closure cinfo fn args =
+    let arity = SMap.find fn.value cinfo.arities in
+    let fn_name = fn.value in
+    let load_size = mov rdi (arity * ptr_size |> ic) in
+    let create_env_ptr = [ call "cm_malloc"; mov r12 rax ] in
+    let inner i arg =
+      mem_imm cinfo arg >>| mov r9 >>| lst =>> mov (dp "r12" (i * ptr_size)) r9
+    in
+    let* store_args =
+      preserve_reg r9 |<< (monadic_mapi args inner >>| List.concat)
+    in
+    let load_argv = mov rdx r12 in
+    let load_argc = mov rsi (List.length args |> ic) in
+    let load_fn = mov rdi (Fndef fn_name) in
+    let load_arity = mov rcx (arity |> ic) in
+    let create_closure = call "create_function" in
+    preserve_reg r12
+      ([ load_size ] >>> create_env_ptr >>> store_args >> load_argv >> load_argc
+     >> load_fn >> load_arity >> create_closure)
+    |> return
+
+  let ld_imm cinfo imm =
+    match imm with
+    | ImmVal v when List.mem v.value cinfo.functions -> alloc_closure cinfo v []
+    | ImmVal v when List.mem v.value std_functions -> alloc_closure cinfo v []
+    | _ -> mem_imm cinfo imm >>| fun x -> [ mov rax x ]
+
+  let fix_align_16 instructions size =
+    instructions @ [ sub rsp (Int.rem size 16 |> ic) ]
+
+  let compile_push_args cinfo (args : imm list) =
+    let inner (xs, arg_i, s) arg =
+      let* loc = mem_imm cinfo arg in
+      match get_arg_loc arg_i with
+      | Some reg -> (xs @ [ Mov (reg, loc) ], arg_i + 1, s) |> return
+      | None ->
+          let* arg_load = ld_imm cinfo arg in
+          (xs @ arg_load, arg_i + 1, s + sizeof arg) |> return
+    in
+    let* instr, _, size = monadic_fold inner ([], 0, 0) args in
+    fix_align_16 instr size |> return
+
+  let rec compile_expr cinfo (e : anf_expr) =
+    match e with
+    | AApply (ImmVal fn, args)
+      when List.mem fn.value std_functions
+           && List.length args == arity_of fn.typ ->
+        compile_push_args cinfo args |>>> compile_fn_call fn.value args
+    | AApply (ImmVal fn, args) ->
+        let argc = List.length args in
+        let alloc_arr =
+          [ mov rdi (argc * ptr_size |> ic); call "cm_malloc"; mov r12 rax ]
+        in
+        let store_arg i arg =
+          ld_imm cinfo arg =>> mov (dp "r12" (i * ptr_size)) rax
+        in
+        let* store_args = monadic_mapi args store_arg >>| concat in
+        let push_array = [ push r12; sub rsp (ic 8) ] in
+        let* load_self =
+          if List.mem fn.value cinfo.functions then
+            alloc_closure cinfo fn [] =>> mov rdi rax
+          else mem_imm cinfo (ImmVal fn) >>| mov rax >>| lst =>> mov rdi rax
+        in
+        let load_argc = mov rsi (argc |> ic) in
+        let pop_argv = [ add rsp (ic 8); pop rdx ] in
+        let call_apply = call "apply_args" in
+        alloc_arr >>> store_args >>> push_array >>> load_self >> load_argc
+        >>> pop_argv >> call_apply |> return
+    | AImm i -> ld_imm cinfo i
+    | Aite (i, t, e) ->
+        let compile_block x = monadic_map x (compile_vb cinfo) >>| concat in
+        let if_id = gen_next_if_id () in
+        let mklabel name = Label (Format.sprintf "%s_%d" name if_id) in
+        let cont = mklabel "cont" in
+        let jmp_to_cont = Jmp (Format.sprintf "cont_%d" if_id) in
+        let then_branch =
+          compile_block t.lets |>>> ld_imm cinfo t.res =>> jmp_to_cont
+        in
+        let else_branch =
+          [ mklabel "else" ] ->>> compile_block e.lets
+          |>>> ld_imm cinfo e.res =>> cont
+        in
+        let* if_part =
+          ld_imm cinfo i
+          =>>> [ cmp rax (ic 0); je (Format.sprintf "else_%d" if_id) ]
+        in
+        if_part ->>> then_branch |>>> else_branch
+    | AClosure (fn, args) -> alloc_closure cinfo fn args
+    | ATuple elements ->
+        let argc = List.length elements in
+        let alloc_tuple =
+          [ mov rdi (argc * ptr_size |> ic); call "cm_malloc"; mov r12 rax ]
+        in
+        let inner i arg =
+          ld_imm cinfo arg =>> mov (dp "r12" (i * ptr_size)) rax
+        in
+        let store_elements = monadic_mapi elements inner >>| concat in
+        preserve_reg r12 |<< (alloc_tuple ->>> store_elements =>> mov rax r12)
+    | ATupleAccess (tuple, index) ->
+        preserve_reg r9
+        |<< (mem_imm cinfo tuple >>| mov r9 >>| lst
+            =>> push (dp "r9" (index * ptr_size))
+            =>> pop rax)
+    | AApply (ImmLit _, _) -> error "Compiler error: Cannot apply literal"
+
+  and compile_vb cinfo (vb : anf_val_binding) =
+    let store =
+      match vb.name.typ with
+      | TyGround TUnit -> []
+      | _ -> SMap.find vb.name.value cinfo.memory |> fun x -> [ mov x rax ]
+    in
+    let* expr = compile_expr cinfo vb.e in
+    expr >>> store |> return
+
+  let rec collect_expr_size (e : anf_val_binding) =
+    match e.e with
+    | Aite (_, t, e) ->
+        (sum_by collect_expr_size) t.lets + (sum_by collect_expr_size) e.lets
+    | _ -> sizeof e.name
+
+  let add_fn_stuff x =
+    let save_base = [ push rbp; mov rbp rsp ] in
+    let ret = [ mov rsp rbp; pop rbp; Ret ] in
+    save_base >>> x >>> ret
+
+  let compile_fn cinfo (fn : anf_fun_binding) =
+    let name = fn.name.value in
+    let cinfo = { cinfo with memory = map_fn_stack fn } in
+    let stack_len =
+      (sum_by sizeof) fn.args
+      + (sum_by sizeof) fn.env
+      + (sum_by collect_expr_size) fn.body.lets
+      + sizeof fn.body.res
+    in
+    let sub_esp = sub rsp (stack_len + reg_size |> align16 |> ic) in
+    let* body = monadic_map fn.body.lets (compile_vb cinfo) >>| concat in
+    let* res = mem_imm cinfo fn.body.res >>| mov rax in
+    let save_args =
+      let rec helper lst i instrs =
+        match (lst, get_arg_loc i) with
+        | [], _ -> instrs
+        | hd :: tl, Some reg ->
+            Mov (SMap.find hd.value cinfo.memory, reg) :: instrs
+            |> helper tl (i + 1)
+        | _, None -> instrs
+      in
+      helper (fn.env >>> fn.args) 0 []
+    in
+    return
+      { name; body = add_fn_stuff ([ sub_esp ] >>> save_args >>> body >> res) }
+
+  let main_fn body =
+    {
+      args = [];
+      env = [];
+      name = { value = "main"; typ = TyGround TInt };
+      body =
+        { lets = body; res = ImmLit { value = LInt 0; typ = TyGround TInt } };
+    }
+
+  let compile ast : (fn list, string) Result.t =
+    let fn_defs, main_fn_body =
+      List.partition_map
+        (function AnfFun fn -> Left fn | AnfVal v -> Right v)
+        ast
+    in
+    let l = List.length in
+    let arities =
+      List.map
+        (fun (fn : anf_fun_binding) -> (fn.name.value, l fn.args + l fn.env))
+        fn_defs
+      |> List.to_seq
+      |> Seq.append
+           (Std.operators
+           |> List.map (fun x -> (x.value, arity_of x.typ))
+           |> List.to_seq)
+      |> SMap.of_seq
+    in
+    let cinfo =
+      {
+        functions = List.map (fun (x : anf_fun_binding) -> x.name.value) fn_defs;
+        memory = SMap.empty;
+        arities;
+      }
+    in
+    let* main_fn =
+      main_fn main_fn_body |> compile_fn cinfo >>| fun x ->
+      { x with name = "main" }
+    in
+    let* all_fns = monadic_map fn_defs (compile_fn cinfo) in
+    main_fn :: all_fns |> return
+end
+
+module AsmRenderer = struct
+  open Asm
+
+  let header =
+    {|
+extern print_int
+extern print_string
+extern create_function
+extern apply_args
+extern cm_malloc
+
+global main
+|}
+
+  let rm = function
+    | Stack d when d > 0 -> Format.sprintf "qword [rbp+%d]" d
+    | Stack d when d < 0 -> Format.sprintf "qword [rbp%d]" d
+    | Stack _ -> Format.sprintf "qword [rbp]"
+    | Reg r -> r
+    | IntConst c -> Format.sprintf "%d" c
+    | Displacement (r, d) when d > 0 -> Format.sprintf "qword [%s+%d]" r d
+    | Displacement (r, d) when d < 0 -> Format.sprintf "qword [%s%d]" r d
+    | Displacement (r, _) -> Format.sprintf "qword [%s]" r
+    | Fndef fname -> fname
+
+  let not_reg = function Reg _ -> false | _ -> true
+
+  let render_instr = function
+    | Mov (src, dst) when not_reg src && not_reg dst ->
+        Format.sprintf "mov r9, %s\n  mov %s, r9" (rm dst) (rm src)
+    | Mov (src, dst) -> Format.sprintf "mov %s, %s" (rm src) (rm dst)
+    | Movzx (src, dst) -> Format.sprintf "movzx %s, %s" (rm src) (rm dst)
+    | Add (src, dst) -> Format.sprintf "add %s, %s" (rm src) (rm dst)
+    | Sub (src, dst) -> Format.sprintf "sub %s, %s" (rm src) (rm dst)
+    | Cmp (src, dst) -> Format.sprintf "cmp %s, %s" (rm src) (rm dst)
+    | Imul (src, dst) -> Format.sprintf "imul %s, %s" (rm src) (rm dst)
+    | Idiv r -> Format.sprintf "idiv %s" (rm r)
+    | Call fn -> Format.sprintf "call %s" fn
+    | Push src -> rm src |> Format.sprintf "push %s"
+    | Pop dst -> rm dst |> Format.sprintf "pop %s"
+    | Int _ -> "int 0x80"
+    | Ret -> "ret"
+    | Label m -> Format.sprintf "%s:" m
+    | Jmp d -> Format.sprintf "jmp %s" d
+    | Je d -> Format.sprintf "je %s" d
+    | Jne d -> Format.sprintf "jne %s" d
+    | Setge d -> Format.sprintf "setge %s" (rm d)
+    | Setle d -> Format.sprintf "setle %s" (rm d)
+    | Setl d -> Format.sprintf "setl %s" (rm d)
+    | Setg d -> Format.sprintf "setg %s" (rm d)
+    | Sete d -> Format.sprintf "sete %s" (rm d)
+    | Cqo -> "cqo"
+
+  let render_instrs il =
+    let add_offset s = Format.sprintf "  %s" s in
+    List.map render_instr il |> List.map add_offset |> String.concat "\n"
+
+  let render_fn p =
+    let nm_dec = Format.sprintf "%s:\n" p.name in
+    Format.sprintf "%s%s" nm_dec (render_instrs p.body)
+
+  let render (p : fn list) =
+    List.map render_fn p |> String.concat "\n\n" |> Format.sprintf "%s%s" header
+end
+
+module AsmOptimizer = struct
+  open Asm
+
+  let meaningful_instr = function
+    | Mov (x, y) when x = y -> false
+    | Add (_, IntConst 0) -> false
+    | Sub (_, IntConst 0) -> false
+    | _ -> true
+
+  let optimize_fn fn = { fn with body = List.filter meaningful_instr fn.body }
+  let optimize = List.map optimize_fn
+end
+
+module Build = struct
+  let create_newdir path perm =
+    if not (Sys.file_exists path) then Sys.mkdir path perm
+
+  let build_dir = "cm_build"
+
+  let make_exe build_loc args program =
+    let () = create_newdir build_dir 0o727 in
+    let asm_out = open_out (build_dir ^ "/program.asm") in
+    let () = Printf.fprintf asm_out "%s" (AsmRenderer.render program) in
+    let () = close_out asm_out in
+    let _ = Sys.command (build_loc ^ args) in
+    ()
+end

--- a/CreeperML/lib/asm.mli
+++ b/CreeperML/lib/asm.mli
@@ -1,0 +1,59 @@
+module Asm : sig
+  open Anf.AnfTypeAst
+  open Monad.Result
+
+  type reg = string
+
+  type storage =
+    | Stack of int
+    | Reg of reg
+    | IntConst of int
+    | Displacement of string * int
+    | Fndef of string
+
+  type instruction =
+    | Mov of storage * storage
+    | Movzx of storage * storage
+    | Add of storage * storage
+    | Sub of storage * storage
+    | Imul of storage * storage
+    | Idiv of storage
+    | Call of string
+    | Push of storage
+    | Pop of storage
+    | Int of int
+    | Ret
+    | Jmp of string
+    | Je of string
+    | Jne of string
+    | Cmp of storage * storage
+    | Setge of storage
+    | Setg of storage
+    | Setle of storage
+    | Setl of storage
+    | Sete of storage
+    | Label of string (* bad *)
+    | Cqo
+
+  type fn = { name : string; body : instruction list }
+
+  val compile : anf_program -> fn list t
+end
+
+module AsmRenderer : sig
+  open Asm
+
+  val render : fn list -> string
+end
+
+module AsmOptimizer : sig
+  open Asm
+
+  val optimize : fn list -> fn list
+end
+
+module Build : sig
+  open Asm
+
+  val make_exe : string -> string -> fn list -> unit
+end

--- a/CreeperML/lib/bindings.c
+++ b/CreeperML/lib/bindings.c
@@ -31,11 +31,6 @@ void bin_print_int(const int i)
     printf("%d\n", i);
 }
 
-void print_int(const int i)
-{
-    printf("%d\n", i);
-}
-
 void print_string_raw(const char *str)
 {
     printf("%s\n", str);

--- a/CreeperML/lib/bindings.c
+++ b/CreeperML/lib/bindings.c
@@ -31,6 +31,11 @@ void bin_print_int(const int i)
     printf("%d\n", i);
 }
 
+void print_int(const int i)
+{
+    printf("%d\n", i);
+}
+
 void print_string_raw(const char *str)
 {
     printf("%s\n", str);

--- a/CreeperML/lib/bindings.c
+++ b/CreeperML/lib/bindings.c
@@ -118,7 +118,6 @@ cmptr apply_args(function *clsr, cmptr argc, cmptr *argv)
 
     function *clsr_old = clsr;
     clsr = (function *)create_function((cmptr)clsr_old->fn, clsr_old->argc, (cmptr)clsr_old->argv, clsr_old->arity, clsr_old->fn_id);
-
     cmptr all_argc = clsr->argc + argc;
 
     // Merge arguments
@@ -129,10 +128,8 @@ cmptr apply_args(function *clsr, cmptr argc, cmptr *argv)
     for (int i = 0; i < clsr->argc; i++)
         clsr->argv[i] = clsr_argv[i];
 
-
     for (int i = clsr->argc; i < all_argc; i++)
         clsr->argv[i] = argv[i - clsr->argc];
-
 
     cmptr awaited = clsr->arity - clsr->argc;
     cmptr applied = min((int)argc, (int)awaited);
@@ -166,7 +163,7 @@ cmptr create_function(cmptr fn, cmptr argc, cmptr argv, cmptr arity, cmptr fn_id
     function *clsr = (function *)cm_malloc(sizeof(function));
     clsr->arity = arity; // Summary size of all arguments
     clsr->fn = (cmptr(*)())fn;
-    clsr->argv = (cmptr*)argv;
+    clsr->argv = (cmptr *)argv;
     clsr->argc = argc;
     clsr->fn_id = fn_id;
 

--- a/CreeperML/lib/dune
+++ b/CreeperML/lib/dune
@@ -27,6 +27,12 @@
  (action
   (run gcc -shared %{deps} -o %{targets})))
 
+(rule
+ (deps bindings.c)
+ (targets bindings.o)
+ (action
+  (run gcc -c %{deps} -o %{targets} -w)))
+
 (library
  (name CreeperML)
  (public_name CreeperML)

--- a/CreeperML/lib/dune
+++ b/CreeperML/lib/dune
@@ -31,7 +31,7 @@
  (deps bindings.c)
  (targets bindings.o)
  (action
-  (run gcc -c %{deps} -o %{targets} -w)))
+  (run gcc -c %{deps} -o %{targets})))
 
 (library
  (name CreeperML)

--- a/CreeperML/lib/infer.ml
+++ b/CreeperML/lib/infer.ml
@@ -317,7 +317,17 @@ module Infer = struct
                     let* acc = acc in
                     bind_lv_typ acc n t)
                   (return env)
-        | _ -> error "isnt tuple")
+        | _ ->
+            let open Lexing in
+            let pos =
+              { pos_fname = ""; pos_lnum = 0; pos_bol = 0; pos_cnum = 0 }
+            in
+            let loc = { start_p = pos; end_p = pos } in
+            let* t =
+              unify (loc, loc) t
+                (new_tuple (List.init (List.length ns) (fun _ -> new_var ())))
+            in
+            bind_lv_typ env lv t)
 
   module ExprRet = struct
     (* type of value returned by tof_expr *)

--- a/CreeperML/test/dune
+++ b/CreeperML/test/dune
@@ -38,7 +38,21 @@
  (instrumentation
   (backend bisect_ppx))
  (link_deps
-  (file ../lib/bindings.co)))
+  (file ../lib/bindings.co)
+  (file ../lib/bindings.o)
+  (file ../build.sh)))
+
+(executable
+ (name test_asm)
+ (modules test_asm)
+ (public_name test_asm)
+ (libraries CreeperML stdio)
+ (instrumentation
+  (backend bisect_ppx))
+ (link_deps
+  (file ../lib/bindings.co)
+  (file ../lib/bindings.o)
+  (file ../build.sh)))
 
 (cram
  (deps
@@ -47,4 +61,7 @@
   ./test_closures.exe
   ./test_anf.exe
   ./test_llvm.exe
-  ../lib/bindings.co))
+  ./test_asm.exe
+  ../lib/bindings.co
+  ../lib/bindings.o
+  ../build.sh))

--- a/CreeperML/test/test_asm.ml
+++ b/CreeperML/test/test_asm.ml
@@ -1,0 +1,24 @@
+open CreeperML
+open CreeperML.Parser_interface.ParserInterface
+open Infer.Infer
+open Indexed_ast.IndexedTypeAst
+open Closure.ClosureConvert
+open Anf
+open Std
+open Asm
+
+let () =
+  let program = from_channel stdin in
+  let ( >>= ) = Result.bind in
+  let apply_db_renaming p = Ok (index_of_typed p) in
+  let apply_closure_convert p = Ok (cf_of_index p) in
+  let apply_anf_convert p = Ok (AnfConvert.anf_of_cf p) in
+  let apply_anf_optimizations p = Ok (AnfOptimizations.optimize_moves p) in
+  let apply_infer p = top_infer Std.typeenv p in
+  program >>= apply_infer >>= apply_db_renaming >>= apply_closure_convert
+  >>= apply_anf_convert >>= apply_anf_optimizations >>= Asm.compile
+  |> function
+  | Ok x ->
+      AsmOptimizer.optimize x
+      |> Build.make_exe "../build.sh" " -d -b \"../../lib/bindings.o\""
+  | Error x -> print_endline x

--- a/CreeperML/test/test_asm.t
+++ b/CreeperML/test/test_asm.t
@@ -12,6 +12,7 @@
   >   helper n 1
   > let () = print_int (fac 5)
   > EOF
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe > /dev/null
   $ ocaml input.ml
   120
@@ -30,6 +31,7 @@
   > let () = print_int (5 / 3)
   > let () = print_int (5 / 3 + 6 / (2 - 1 + 7) / 2 * 3)
   > EOF
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe > /dev/null
   $ ocaml input.ml
   10932911
@@ -49,6 +51,7 @@
   > let id x = (id2 x) + (id2 (x + 1))
   > let () = print_int (id 5)
   > EOF
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe > /dev/null
   $ ocaml input.ml
   15
@@ -64,6 +67,7 @@
   > let f t = fac t (fun x -> x)
   > let () = print_int (f 7)
   > EOF
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe > /dev/null
   $ ocaml input.ml
   5040
@@ -79,6 +83,7 @@
   > let mul m n k = k (n * m)
   > let () = plus 1 2 (fun x -> mul 10 x print_int)   
   > EOF
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe > /dev/null
   $ ocaml input.ml
   30
@@ -94,6 +99,7 @@
   > let rec fac n k = if n <= 1 then k n else fac (n - 1) (fun m -> k (m * n))
   > let () = fac 6 print_int   
   > EOF
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe > /dev/null
   $ ocaml input.ml
   720
@@ -112,6 +118,7 @@
   >  else ()
   > let () = repeat (fun n -> print_int (fib n)) 30   
   > EOF
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe > /dev/null
   $ ocaml input.ml
   1346269832040514229317811196418121393750254636828657177111094667654181258415979876103772331448955342113853211
@@ -157,6 +164,7 @@
   > let () = print_int a
   > let () = print_int b
   > let () = print_int c  
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe > /dev/null
   $ ocaml input.ml
   123
@@ -174,6 +182,7 @@
   > let (e, f) = add_pair (1, 2) (3, 4)
   > let () = print_int e
   > let () = print_int f   
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe > /dev/null
   $ ocaml input.ml
   46
@@ -194,6 +203,7 @@
   > add x 5 (fun x ->
   > forward (apply id x) print_int
   > ))
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe > /dev/null
   $ ocaml input.ml
   17
@@ -210,6 +220,7 @@
   > let p2 = p1 3 4
   > let p3 = p2 5 6
   > let () = print_int p3
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe > /dev/null
   $ ocaml input.ml
   21
@@ -223,6 +234,7 @@
   $ cat > input.ml <<- EOF
   > let f a b = let g c d = let h x y = let j z w = a + b + c + d + x + y + z + w in j in h in g
   > let () = print_int (f 1 2 3 4 5 6 7 8) 
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe > /dev/null
   $ ocaml input.ml
   36
@@ -235,6 +247,7 @@
   $ cat > input.ml <<- EOF
   > let f rdi rsi rdx rcx r8 r9 stack1 stack2 stack3 = rdi + rsi + rdx + rcx + r8 + r9 + stack1 + stack2 + stack3
   > let () = print_int (f 1 2 3 4 5 6 7 8 9)
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe > /dev/null
   $ ocaml input.ml
   45
@@ -248,6 +261,7 @@
   $ cat > input.ml <<- EOF
   > let rec fib n k = if n <= 1 then k n else fib (n - 2) (fun a -> fib (n - 1) (fun b -> k (a + b)))
   > let () = print_int (fib 8 (fun w -> w))
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe > /dev/null
   $ ocaml input.ml
   21

--- a/CreeperML/test/test_asm.t
+++ b/CreeperML/test/test_asm.t
@@ -1,0 +1,277 @@
++------------------+
+|  Factorial test  |
++------------------+
+  $ cat > input.ml <<- EOF
+  > let fac n =
+  >   let rec helper n acc =
+  >     if n <= 1 then 
+  >       acc
+  >     else
+  >       helper (n - 1) (n * acc)
+  >     in
+  >   helper n 1
+  > let () = print_int (fac 5)
+  > EOF
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ ocaml input.ml
+  120
+  $ cm_build/program
+  120
+
+
++-----------------------------------------------+
+|  Maths test (print_int is done with newline)  |
++-----------------------------------------------+
+  $ cat > input.ml <<- EOF
+  > let () = print_int (5 + 5)
+  > let () = print_int (1 + 5 + 3)
+  > let () = print_int (1 * 5 - 2)
+  > let () = print_int (3 * 9 - 2 + 4)
+  > let () = print_int (5 / 3)
+  > let () = print_int (5 / 3 + 6 / (2 - 1 + 7) / 2 * 3)
+  > EOF
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ ocaml input.ml
+  10932911
+  $ cm_build/program
+  10
+  9
+  3
+  29
+  1
+  1
+
++-------------------------+
+|  Simple function calls  |
++-------------------------+
+  $ cat > input.ml <<- EOF
+  > let id2 x = x + 2
+  > let id x = (id2 x) + (id2 (x + 1))
+  > let () = print_int (id 5)
+  > EOF
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ ocaml input.ml
+  15
+  $ cm_build/program
+  15
+
+
++----------------------+
+|  Factorial with CPS  |
++----------------------+
+  $ cat > input.ml <<- EOF
+  > let rec fac n k = if n <= 1 then k n else fac (n - 1) (fun m -> k (m * n))
+  > let f t = fac t (fun x -> x)
+  > let () = print_int (f 7)
+  > EOF
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ ocaml input.ml
+  5040
+  $ cm_build/program
+  5040
+
+
++-------------------------+
+|  Another test with CPS  |
++-------------------------+
+  $ cat > input.ml <<- EOF
+  > let plus m n k = k (n + m)
+  > let mul m n k = k (n * m)
+  > let () = plus 1 2 (fun x -> mul 10 x print_int)   
+  > EOF
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ ocaml input.ml
+  30
+  $ cm_build/program
+  30
+
+
++-----------------------------+
+|  Factorial with CPS         |
+|  Passing print_int directly |
++-----------------------------+
+  $ cat > input.ml <<- EOF
+  > let rec fac n k = if n <= 1 then k n else fac (n - 1) (fun m -> k (m * n))
+  > let () = fac 6 print_int   
+  > EOF
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ ocaml input.ml
+  720
+  $ cm_build/program
+  720
+
+
++------------------------+
+|  30 fibonacci numbers  |
++------------------------+
+  $ cat > input.ml <<- EOF
+  > let rec fib n = if n < 2 then 1 else (fib (n - 1)) + (fib (n - 2))
+  > let rec repeat fn n =
+  >  let () = fn n in  
+  >  if n > 0 then (repeat fn (n - 1))
+  >  else ()
+  > let () = repeat (fun n -> print_int (fib n)) 30   
+  > EOF
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ ocaml input.ml
+  1346269832040514229317811196418121393750254636828657177111094667654181258415979876103772331448955342113853211
+  $ cm_build/program
+  1346269
+  832040
+  514229
+  317811
+  196418
+  121393
+  75025
+  46368
+  28657
+  17711
+  10946
+  6765
+  4181
+  2584
+  1597
+  987
+  610
+  377
+  233
+  144
+  89
+  55
+  34
+  21
+  13
+  8
+  5
+  3
+  2
+  1
+  1
+
++------------------------+
+|  Simple tuple example  |
++------------------------+
+  $ cat > input.ml <<- EOF
+  > let t = (1, 2, 3)
+  > let (a, b, c) = t
+  > let () = print_int a
+  > let () = print_int b
+  > let () = print_int c  
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ ocaml input.ml
+  123
+  $ cm_build/program
+  1
+  2
+  3
+
+
++----------------------------+
+|  Adding pairs with tuples  |
++----------------------------+
+  $ cat > input.ml <<- EOF
+  > let add_pair (a, b) (c, d) = (a + c, b + d)
+  > let (e, f) = add_pair (1, 2) (3, 4)
+  > let () = print_int e
+  > let () = print_int f   
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ ocaml input.ml
+  46
+  $ cm_build/program
+  4
+  6
+
++-----------------------+
+|  Another CPS example  |
++-----------------------+
+  $ cat > input.ml <<- EOF
+  > let mul a b k = k (a * b)
+  > let forward x k = k x
+  > let apply f x = f x
+  > let add a b k = k (a + b)
+  > let id x = x
+  > let () = mul 3 4 (fun x ->
+  > add x 5 (fun x ->
+  > forward (apply id x) print_int
+  > ))
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ ocaml input.ml
+  17
+  $ cm_build/program
+  17
+
+
++-----------------------+
+|  Partial application  |
++-----------------------+
+  $ cat > input.ml <<- EOF
+  > let f a b c = let g x y z = x + a + y + z + b + c in g
+  > let p1 = f 1 2
+  > let p2 = p1 3 4
+  > let p3 = p2 5 6
+  > let () = print_int p3
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ ocaml input.ml
+  21
+  $ cm_build/program
+  21
+
+
++------------------------+
+|  Partial applications  |
++------------------------+
+  $ cat > input.ml <<- EOF
+  > let f a b = let g c d = let h x y = let j z w = a + b + c + d + x + y + z + w in j in h in g
+  > let () = print_int (f 1 2 3 4 5 6 7 8) 
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ ocaml input.ml
+  36
+  $ cm_build/program
+  36
+
++-------------------------+
+|  Passing through stack  |
++-------------------------+
+  $ cat > input.ml <<- EOF
+  > let f rdi rsi rdx rcx r8 r9 stack1 stack2 stack3 = rdi + rsi + rdx + rcx + r8 + r9 + stack1 + stack2 + stack3
+  > let () = print_int (f 1 2 3 4 5 6 7 8 9)
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ ocaml input.ml
+  45
+  $ cm_build/program
+  45
+
+
++------------------+
+|  Stolen CPS Fib  |
++------------------+
+  $ cat > input.ml <<- EOF
+  > let rec fib n k = if n <= 1 then k n else fib (n - 2) (fun a -> fib (n - 1) (fun b -> k (a + b)))
+  > let () = print_int (fib 8 (fun w -> w))
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ ocaml input.ml
+  21
+  $ cm_build/program
+  21
+
+
++-----------------------+
+|  Test CreeperML logo  |
++-----------------------+
+  $ cat > input.ml <<- EOF
+  > let x = print_int
+  > let () = x 123
+  $ cat input.ml | ./test_asm.exe
+  
+     ___     ___        _____                               __  __ _
+    |   |   |   |      / ____|                             |  \/  | |
+    |___|___|___|     | |     _ __ ___  ___ _ __   ___ _ __| \  / | |
+       _|   |_        | |    | '__/ _ \/ _ \ '_ \ / _ \ '__| |\/| | |
+      |  ___  |       | |____| | |  __/  __/ |_) |  __/ |  | |  | | |____
+      |_|   |_|        \_____|_|  \___|\___| .__/ \___|_|  |_|  |_|______|
+                                           |_|
+  👌 Successful run
+  $ ocaml input.ml
+  123
+  $ cm_build/program
+  123

--- a/CreeperML/test/test_asm.t
+++ b/CreeperML/test/test_asm.t
@@ -290,3 +290,27 @@
   123
   $ cm_build/program
   123
+
+
+  $ cat > input.ml <<- EOF
+  > let rec fix f x = f (fix f) x
+  > let map f p = let (a,b) = p in (f a, f b)
+  > let fixpoly l =
+  > fix (fun self l -> map (fun li x -> li (self l) x) l) l
+  > let feven p n =
+  > let (e, o) = p in
+  > if n == 0 then 1 else o (n - 1)
+  > let fodd p n =
+  > let (e, o) = p in
+  > if n == 0 then 0 else e (n - 1)
+  > let tie = fixpoly (feven, fodd)
+  > let () =
+  > let (even,odd) = tie in
+  > print_int (odd 1)
+  > EOF
+  $ chmod +x ../build.sh
+  $ cat input.ml | ./test_asm.exe > /dev/null
+  $ cm_build/program
+  1
+  $ ocaml input.ml
+  1

--- a/CreeperML/test/test_asm.t
+++ b/CreeperML/test/test_asm.t
@@ -261,6 +261,7 @@
   $ cat > input.ml <<- EOF
   > let x = print_int
   > let () = x 123
+  $ chmod +x ../build.sh
   $ cat input.ml | ./test_asm.exe
   
      ___     ___        _____                               __  __ _


### PR DESCRIPTION
Добавлен ASM с поддержкой
- целых чисел
- функций и частичных применений с замыканиями
- кортежи

Работают
- факториал
- факториал цпс
- фибоначчи
- фибоначчи цпс
- и еще разные тесты, все в test_asm.t

Если эффективность снова будет проблемой, перепишу на Buffer вместо выстраивания кода из типов и последующего преобразования в строку сразу буду писать в буфер.

Компиляция ASM из строки делается через nasm, линкуется gcc
